### PR TITLE
Add URL scheme for deep linking

### DIFF
--- a/Sila/Info.plist
+++ b/Sila/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>im.agg.Sila</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sila</string>
+			</array>
+		</dict>
+	</array>
 	<key>INAlternativeAppNames</key>
 	<array>
 		<dict>


### PR DESCRIPTION
I’d like to add Silas to [Air Launcher](https://apps.apple.com/ca/app/airlauncher-quick-launcher/id6477550630) without going through Shortcuts.

https://github.com/agg23/Sila/assets/12936379/7cd0c75f-10cb-4555-9e3c-47a7f67ebaff