### PR TITLE
Add main window resizing support

### DIFF
--- a/Sila/SilaApp.swift
+++ b/Sila/SilaApp.swift
@@ -32,8 +32,7 @@ struct SilaAppApp: App {
             // This `nil` ID is used to bypass a bug. See inside of `MainWindowView`
             MainWindowView(id: id)
                 .mainWindow()
-                // This is the default window size of the launching animation
-                .frame(width: 1280.0, height: 720.0)
+                .frame(minWidth: defaultWindowSize.width, minHeight: defaultWindowSize.height)
                 // For some reason we crash if we put this environment on the window
                 .environment(self.router)
         } defaultValue: {
@@ -41,6 +40,8 @@ struct SilaAppApp: App {
             // TODO: This doesn't work for some reason
             return "main"
         }
+        // This is the default window size of the launching animation
+        .defaultSize(defaultWindowSize)
         .windowResizability(.contentSize)
         .environment(\.authController, self.authController)
 
@@ -53,7 +54,7 @@ struct SilaAppApp: App {
             STREAM_MOCK()
         }
         .environment(\.authController, self.authController)
-        .defaultSize(CGSize(width: 1280.0, height: 720.0))
+        .defaultSize(defaultWindowSize)
         .windowStyle(.plain)
 
         #if VOD_ENABLED
@@ -61,7 +62,9 @@ struct SilaAppApp: App {
             TwitchVoDVideoView(video: video)
         }
         .environment(\.authController, self.authController)
-        .defaultSize(CGSize(width: 1280.0, height: 720.0))
+        .defaultSize(defaultWindowSize)
         #endif
     }
+    
+    private let defaultWindowSize = CGSize(width: 1280.0, height: 720.0)
 }

--- a/Sila/View/Category/CategoryGridView.swift
+++ b/Sila/View/Category/CategoryGridView.swift
@@ -20,12 +20,10 @@ struct CategoryGridView: View {
 
     var body: some View {
         LazyVGrid(columns: [
-            GridItem(spacing: 16),
-            GridItem(spacing: 16),
-            GridItem(spacing: 16),
-            GridItem(spacing: 16),
-            GridItem(spacing: 16),
-            GridItem(spacing: 16)
+            GridItem(
+                .adaptive(minimum: 150, maximum: 200),
+                spacing: 16
+            )
         ], spacing: 16){
             ForEach(self.categories, id: \.id) { category in
                 CategoryButtonView(category: category)

--- a/Sila/View/Channel/ChannelGridView.swift
+++ b/Sila/View/Channel/ChannelGridView.swift
@@ -18,12 +18,10 @@ struct ChannelGridView: View {
         })
 
         LazyVGrid(columns: [
-            GridItem(),
-            GridItem(),
-            GridItem(),
-            GridItem(),
-            GridItem(),
-            GridItem()
+            GridItem(
+                .adaptive(minimum: 150, maximum: 200),
+                spacing: 16
+            )
         ], content: {
             ForEach(sortedChannels, id: \.id) { user in
                 ChannelButtonView(channel: user)

--- a/Sila/View/Stream/StreamGridView.swift
+++ b/Sila/View/Stream/StreamGridView.swift
@@ -20,10 +20,10 @@ struct StreamGridView: View {
 
     var body: some View {
         LazyVGrid(columns: [
-            GridItem(spacing: 16),
-            GridItem(spacing: 16),
-            GridItem(spacing: 16),
-            GridItem(spacing: 16)
+            GridItem(
+                .adaptive(minimum: 250, maximum: 350),
+                spacing: 16
+            )
         ], spacing: 16) {
             ForEach(self.streams) { stream in
                 StreamButtonView(stream: stream)

--- a/Sila/View/VOD/VODGridView.swift
+++ b/Sila/View/VOD/VODGridView.swift
@@ -20,10 +20,10 @@ struct VODGridView: View {
 
     var body: some View {
         LazyVGrid(columns: [
-            GridItem(),
-            GridItem(),
-            GridItem(),
-            GridItem()
+            GridItem(
+                .adaptive(minimum: 250, maximum: 350),
+                spacing: 16
+            )
         ], content: {
             ForEach(self.videos, id: \.id) { video in
                 VODButtonView(video: video)


### PR DESCRIPTION
# Motivation

When I first opened Sila I attempted to resize the height of the main window to display more content but was unable to since the window currently has a fixed size.

# Changes

* Create property abstraction for default window size
* Specify `minWidth` / `minHeight` for main window content as well as a `defaultWindowSize(...)`
* Convert `LazyVGrid` `GridItems` to utilize `.adaptive(...)` layouts

<details>

<summary>Video</summary>

https://github.com/agg23/Sila/assets/671271/33c7b62e-bbf0-4334-bde8-9901ce7f5005

</details>
