### PR TITLE
Update corner radius language

### DIFF
--- a/Sila/Pages/SettingsView.swift
+++ b/Sila/Pages/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
                 }
 
                 Section("Playback") {
-                    Toggle("Shrink Video Corners", isOn: self.$smallBorderRadius)
+                    Toggle("Show Video Corners", isOn: self.$smallBorderRadius)
                     Toggle("Dim Surroundings", isOn: self.$dimSurroundings)
                 }
 


### PR DESCRIPTION
I probably would have changed more, I would have preferred this setting to start "ON" and be something like "Use Vision Pro Round Corners".  It's very difficult to describe settings that when you click them ON it turns something OFF.

I don't think the "shrink" video corners language makes sense here.  While you do shrink the corner radius, what's shown actually increases as a smaller corner radius fits much further into the original rectangle video.  How far does apple let you push the corners?  Can you make it a true square?  I can imagine a few games with minimaps that would benefit from that instead of a smaller radius, then this setting could be "Show Full Video Corners".